### PR TITLE
Fix deploy stage of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ deploy:
   file_glob: true
   on:
     tags: true
-    repo: kabanero-io/kabanero-stack-hub
+    repo: IBM/cp4apps-hub


### PR DESCRIPTION
This fixes the error on Travis release builds due to mismatched repository names.